### PR TITLE
feat: Добавлен сетевой слой для API расписаний

### DIFF
--- a/openapi-generator-config.yaml
+++ b/openapi-generator-config.yaml
@@ -1,0 +1,3 @@
+generate:
+  - types
+  - client

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,1128 @@
+openapi: 3.0.3
+info:
+  title: API.Rasp.Yandex.Net
+  description: API Яндекс.Расписаний
+  version: 3.0.0
+servers:
+- url: https://api.rasp.yandex.net
+tags:
+- name: Расписание между станциями
+  description: Методы для работы с расписанием между станциями
+- name: Расписание на станции
+  description: Методы для работы с расписанием на конкретной станции
+- name: Список станций маршрута
+  description: Методы для получения списка станций маршрута
+- name: Ближайшие станции
+  description: Методы для работы с ближайшими станциями
+- name: Ближайший населенный пункт
+  description: Методы для работы с ближайшими населенными пунктами
+- name: Перевозчики
+  description: Методы для работы с информацией о перевозчиках
+- name: Список станций
+  description: Методы для работы со списком станций
+- name: Копирайт
+  description: Методы для получения информации о копирайте
+
+paths:
+  /v3.0/search/:
+    get:
+      tags:
+      - Расписание между станциями
+      summary: Расписание рейсов между станциями
+      operationId: getSearch
+      parameters:
+      - name: apikey
+        in: query
+        description: API key
+        required: true
+        schema:
+          type: string
+      - name: from
+        in: query
+        description: Код станции отправления
+        required: true
+        schema:
+          type: string
+      - name: to
+        in: query
+        description: Код станции прибытия
+        required: true
+        schema:
+          type: string
+      - name: format
+        in: query
+        description: json или xml
+        required: false
+        schema:
+          type: string
+      - name: lang
+        in: query
+        description: lang
+        required: false
+        schema:
+          type: string
+      - name: date
+        in: query
+        description: date
+        required: false
+        schema:
+          type: string
+      - name: transport_types
+        in: query
+        description: Тип транспортного средства
+        required: false
+        schema:
+          type: string
+      - name: system
+        in: query
+        description: Система кодирования, в которой указывается код станции отправления и код станции прибытия (параметры from, to) в запросе
+        required: false
+        schema:
+          type: string
+      - name: show_systems
+        in: query
+        description: Система кодирования, коды которой следует добавить к описанию станций в результатах поиска
+        required: false
+        schema:
+          type: string
+      - name: add_days_mask
+        in: query
+        description: Признак, который указывает, что для каждой нитки в ответе следует вернуть календарь хождения — элемент schedule, вложенный в элемент segments.
+        required: false
+        schema:
+          type: boolean
+      - name: result_timezone
+        in: query
+        description: Часовой пояс, для которого следует указывать даты и времена в ответе
+        required: false
+        schema:
+          type: string
+      - name: transfers
+        in: query
+        description: Признак, разрешающий добавить к результатам поиска маршруты с пересадками.
+        required: false
+        schema:
+          type: boolean
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/searchResponse'
+
+  /v3.0/nearest_stations/:
+    get:
+      tags:
+      - Ближайшие станции
+      summary: Список ближайших станций
+      operationId: getNearestStations
+      parameters:
+      - name: apikey
+        in: query
+        description: API key
+        required: true
+        schema:
+          type: string
+      - name: lat
+        in: query
+        description: широта
+        required: true
+        schema:
+          type: number
+      - name: lng
+        in: query
+        description: долгота
+        required: true
+        schema:
+          type: number
+      - name: distance
+        in: query
+        description: радиус охвата
+        required: true
+        schema:
+          type: integer
+      - name: format
+        in: query
+        description: json или xml
+        required: false
+        schema:
+          type: string
+      - name: lang
+        in: query
+        description: lang
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Stations'
+  /v3.0/schedule/:
+    get:
+      tags:
+      - Расписание на станции
+      summary: Расписание на станции
+      operationId: getSchedule
+      parameters:
+      - name: apikey
+        in: query
+        description: API key
+        required: true
+        schema:
+          type: string
+      - name: station
+        in: query
+        description: Код станции
+        required: true
+        schema:
+          type: string
+      - name: date
+        in: query
+        description: Дата в формате YYYY-MM-DD
+        required: false
+        schema:
+          type: string
+      - name: transport_types
+        in: query
+        description: Типы транспорта (plane,train,suburban,bus,water,helicopter)
+        required: false
+        schema:
+          type: string
+      - name: direction
+        in: query
+        description: Направление (all,arrival,departure)
+        required: false
+        schema:
+          type: string
+      - name: event
+        in: query
+        description: Событие (all,arrival,departure)
+        required: false
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Количество записей в ответе
+        required: false
+        schema:
+          type: integer
+      - name: offset
+        in: query
+        description: Смещение от начала списка
+        required: false
+        schema:
+          type: integer
+      - name: format
+        in: query
+        description: Формат ответа (json или xml)
+        required: false
+        schema:
+          type: string
+      - name: lang
+        in: query
+        description: Язык ответа
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScheduleResponse'
+
+  /v3.0/thread/:
+    get:
+      tags:
+      - Список станций маршрута
+      summary: Список станций маршрута
+      operationId: getThread
+      parameters:
+      - name: apikey
+        in: query
+        description: API key
+        required: true
+        schema:
+          type: string
+      - name: uid
+        in: query
+        description: Идентификатор нитки
+        required: true
+        schema:
+          type: string
+      - name: from
+        in: query
+        description: Код станции отправления (опционально)
+        required: false
+        schema:
+          type: string
+      - name: to
+        in: query
+        description: Код станции прибытия (опционально)
+        required: false
+        schema:
+          type: string
+      - name: date
+        in: query
+        description: Дата в формате YYYY-MM-DD
+        required: false
+        schema:
+          type: string
+      - name: format
+        in: query
+        description: Формат ответа (json или xml)
+        required: false
+        schema:
+          type: string
+      - name: lang
+        in: query
+        description: Язык ответа
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThreadResponse'
+
+  /v3.0/nearest_station/:
+    get:
+      tags:
+      - Ближайшие станции
+      summary: Ближайшая станция
+      operationId: getNearestStation
+      parameters:
+      - name: apikey
+        in: query
+        description: API key
+        required: true
+        schema:
+          type: string
+      - name: lat
+        in: query
+        description: Широта
+        required: true
+        schema:
+          type: number
+      - name: lng
+        in: query
+        description: Долгота
+        required: true
+        schema:
+          type: number
+      - name: distance
+        in: query
+        description: Радиус охвата в метрах
+        required: true
+        schema:
+          type: integer
+      - name: station_types
+        in: query
+        description: Типы станций (train_station, airport, bus_station, etc.)
+        required: false
+        schema:
+          type: string
+      - name: transport_types
+        in: query
+        description: Типы транспорта (plane,train,suburban,bus,water,helicopter)
+        required: false
+        schema:
+          type: string
+      - name: format
+        in: query
+        description: Формат ответа (json или xml)
+        required: false
+        schema:
+          type: string
+      - name: lang
+        in: query
+        description: Язык ответа
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NearestStationResponse'
+
+  /v3.0/nearest_settlement/:
+    get:
+      tags:
+      - Ближайший населенный пункт
+      summary: Ближайший населенный пункт
+      operationId: getNearestSettlement
+      parameters:
+      - name: apikey
+        in: query
+        description: API key
+        required: true
+        schema:
+          type: string
+      - name: lat
+        in: query
+        description: Широта
+        required: true
+        schema:
+          type: number
+      - name: lng
+        in: query
+        description: Долгота
+        required: true
+        schema:
+          type: number
+      - name: distance
+        in: query
+        description: Радиус охвата в километрах
+        required: false
+        schema:
+          type: integer
+      - name: format
+        in: query
+        description: Формат ответа (json или xml)
+        required: false
+        schema:
+          type: string
+      - name: lang
+        in: query
+        description: Язык ответа
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NearestSettlementResponse'
+
+  /v3.0/carrier/:
+    get:
+      tags:
+      - Перевозчики
+      summary: Информация о перевозчике
+      operationId: getCarrier
+      parameters:
+      - name: apikey
+        in: query
+        description: API key
+        required: true
+        schema:
+          type: string
+      - name: code
+        in: query
+        description: Код перевозчика
+        required: true
+        schema:
+          type: string
+      - name: system
+        in: query
+        description: Система кодирования
+        required: false
+        schema:
+          type: string
+      - name: format
+        in: query
+        description: Формат ответа (json или xml)
+        required: false
+        schema:
+          type: string
+      - name: lang
+        in: query
+        description: Язык ответа
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CarrierResponse'
+
+  /v3.0/stations_list/:
+    get:
+      tags:
+      - Список станций
+      summary: Список станций
+      operationId: getStationsList
+      parameters:
+      - name: apikey
+        in: query
+        description: API key
+        required: true
+        schema:
+          type: string
+      - name: format
+        in: query
+        description: Формат ответа (json или xml)
+        required: false
+        schema:
+          type: string
+      - name: lang
+        in: query
+        description: Язык ответа
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            text/html:
+              schema:
+                $ref: '#/components/schemas/StationsListResponse'
+
+  /v3.0/copyright/:
+    get:
+      tags:
+      - Копирайт
+      summary: Информация о копирайте
+      operationId: getCopyright
+      parameters:
+      - name: apikey
+        in: query
+        description: API key
+        required: true
+        schema:
+          type: string
+      - name: format
+        in: query
+        description: Формат ответа (json или xml)
+        required: false
+        schema:
+          type: string
+      - name: lang
+        in: query
+        description: Язык ответа
+        required: false
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CopyrightResponse'
+components:
+  schemas:
+    searchResponse:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        interval_segments:
+          $ref: '#/components/schemas/interval_segments'
+        segments:
+          $ref: '#/components/schemas/segments'
+        search:
+          $ref: '#/components/schemas/search'
+    interval_segments:
+      type: array
+      items:
+        $ref: '#/components/schemas/interval_segment'
+    segments:
+      type: array
+      items:
+        $ref: '#/components/schemas/segment'
+    search:
+      type: object
+      properties:
+        date:
+          type: string
+        to:
+          $ref: '#/components/schemas/searchTo'
+        from:
+          $ref: '#/components/schemas/searchFrom'
+    interval_segment:
+      type: object
+      properties:
+        from:
+          $ref: '#/components/schemas/segmentFrom'
+        thread:
+          $ref: '#/components/schemas/thread'
+        departure_platform:
+          type: string
+        stops:
+          type: string
+        departure_terminal:
+          type: string
+        to:
+          $ref: '#/components/schemas/segmentTo'
+        has_transfers:
+          type: boolean
+        tickets_info:
+          $ref: '#/components/schemas/tickets_info'
+        duration:
+          type: number
+        arrival_terminal:
+          type: string
+        start_date:
+          type: string
+        arrival_platform:
+          type: string
+    segment:
+      type: object
+      properties:
+        arrival:
+          type: string
+        from:
+          $ref: '#/components/schemas/segmentFrom'
+        thread:
+          $ref: '#/components/schemas/thread'
+        departure_platform:
+          type: string
+        departure:
+          type: string
+        stops:
+          type: string
+        departure_terminal:
+          type: string
+        to:
+          $ref: '#/components/schemas/segmentTo'
+        has_transfers:
+          type: boolean
+        tickets_info:
+          $ref: '#/components/schemas/tickets_info'
+        duration:
+          type: number
+        arrival_terminal:
+          type: string
+        start_date:
+          type: string
+        arrival_platform:
+          type: string
+    segmentFrom:
+      type: object
+      properties:
+        code:
+          type: string
+        title:
+          type: string
+        station_type:
+          type: string
+        station_type_name:
+          type: string
+        popular_title:
+          type: string
+        short_title:
+          type: string
+        transport_type:
+          type: string
+        type:
+          type: string
+    thread:
+      type: object
+      properties:
+        uid:
+          type: string
+        title:
+          type: string
+        interval:
+          $ref: '#/components/schemas/interval'
+        number:
+          type: string
+        short_title:
+          type: string
+        thread_method_link:
+          type: string
+        carrier:
+          $ref: '#/components/schemas/carrier'
+        transport_type:
+          type: string
+        vehicle:
+          type: string
+        transport_subtype:
+          $ref: '#/components/schemas/transport_subtype'
+        express_type:
+          type: string
+    segmentTo:
+      type: object
+      properties:
+        code:
+          type: string
+        title:
+          type: string
+        station_type:
+          type: string
+        station_type_name:
+          type: string
+        popular_title:
+          type: string
+        short_title:
+          type: string
+        transport_type:
+          type: string
+        type:
+          type: string
+    interval:
+      type: object
+      properties:
+        density:
+          type: string
+        end_time:
+          type: string
+        begin_time:
+          type: string
+    tickets_info:
+      type: object
+      properties:
+        et_marker:
+          type: boolean
+        places:
+          type: array
+          items:
+            $ref: '#/components/schemas/place'
+    place:
+      type: object
+      properties:
+        currency:
+          type: string
+        price:
+          $ref: '#/components/schemas/price'
+        name:
+          type: string
+    price:
+      type: object
+      properties:
+        cents:
+          type: number
+        whole:
+          type: number
+    carrier:
+      type: object
+      properties:
+        code:
+          type: number
+        contacts:
+          type: string
+        url:
+          type: string
+        logo_svg:
+          type: string
+        title:
+          type: string
+        phone:
+          type: string
+        codes:
+          $ref: '#/components/schemas/codes'
+        address:
+          type: string
+        logo:
+          type: string
+        email:
+          type: string
+    transport_subtype:
+      type: object
+      properties:
+        color:
+          type: string
+        code:
+          type: string
+        title:
+          type: string
+    codes:
+      type: object
+      properties:
+        icao:
+          type: string
+        sirena:
+          type: string
+        iata:
+          type: string
+    searchFrom:
+      type: object
+      properties:
+        code:
+          type: string
+        type:
+          type: string
+        popular_title:
+          type: string
+        short_title:
+          type: string
+        title:
+          type: string
+    searchTo:
+      type: object
+      properties:
+        code:
+          type: string
+        type:
+          type: string
+        popular_title:
+          type: string
+        short_title:
+          type: string
+        title:
+          type: string
+    Stations:
+      type: object
+      properties:
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        stations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Station'
+    Pagination:
+      type: object
+      properties:
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+    Station:
+      type: object
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        short_title:
+          type: string
+        popular_title:
+          type: string
+        code:
+          type: string
+        lat:
+          type: number
+        lng:
+          type: number
+        station_type:
+          type: string
+        station_type_name:
+          type: string
+        transport_type:
+          type: string
+        distance:
+          type: number
+        majority:
+          type: integer
+        type_choices:
+          $ref: '#/components/schemas/Schedule'
+    Schedule:
+      type: object
+      properties:
+        desktop_url:
+          type: string
+        touch_url:
+          type: string
+    
+    CarrierResponse:
+      properties:
+        carrier:
+          properties:
+            code:
+              type: integer
+            codes:
+              properties:
+                express:
+                  type: string
+                iata:
+                  type: string
+                sirena:
+                  type: string
+              type: object
+            contacts:
+              type: string
+            email:
+              type: string
+            logo:
+              type: string
+            logo_svg:
+              type: string
+            phone:
+              type: string
+            title:
+              type: string
+            url:
+              type: string
+          type: object
+      type: object
+    CopyrightResponse:
+      properties:
+        copyright:
+          properties:
+            text:
+              type: string
+            url:
+              type: string
+          type: object
+      type: object
+    NearestSettlementResponse:
+      properties:
+        code:
+          type: string
+        distance:
+          type: number
+        settlement:
+          properties:
+            code:
+              type: string
+            lat:
+              type: number
+            lng:
+              type: number
+            title:
+              type: string
+          type: object
+        station_type:
+          type: string
+        station_type_name:
+          type: string
+        title:
+          type: string
+        type:
+          type: string
+        type_choices:
+          items:
+            type: string
+          type: array
+      type: object
+    NearestStationResponse:
+      properties:
+        distance:
+          type: number
+        station:
+          properties:
+            code:
+              type: string
+            lat:
+              type: number
+            lng:
+              type: number
+            station_type:
+              type: string
+            station_type_name:
+              type: string
+            title:
+              type: string
+            transport_type:
+              type: string
+            type:
+              type: string
+          type: object
+      type: object
+    ScheduleResponse:
+      properties:
+        date:
+          type: string
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+        schedule:
+          items:
+            properties:
+              arrival:
+                type: string
+              departure:
+                type: string
+              platform:
+                type: string
+              stops:
+                type: string
+              terminal:
+                type: string
+              thread:
+                $ref: '#/components/schemas/Thread'
+            type: object
+          type: array
+        station:
+          properties:
+            code:
+              type: string
+            station_type:
+              type: string
+            title:
+              type: string
+            transport_type:
+              type: string
+    StationsListResponse:
+      type: object
+      properties:
+        countries:
+          type: array
+          items:
+            $ref: '#/components/schemas/country'
+    country:
+      type: object
+      properties:
+        regions:
+          type: array
+          items:
+            $ref: '#/components/schemas/region'
+        codes:
+          $ref: '#/components/schemas/stationCodes'
+        title:
+          type: string
+    region:
+      type: object
+      properties:
+        settlements:
+          type: array
+          items:
+            $ref: '#/components/schemas/settlement'
+        codes:
+          $ref: '#/components/schemas/stationCodes'
+        title:
+          type: string
+    settlement:
+      type: object
+      properties:
+        title:
+          type: string
+        codes:
+          $ref: '#/components/schemas/stationCodes'
+        stations:
+          type: array
+          items:
+            $ref: '#/components/schemas/station'
+    station:
+      type: object
+      properties:
+        direction:
+          type: string
+        codes:
+          $ref: '#/components/schemas/stationCodes'
+        station_type:
+          type: string
+        title:
+          type: string
+        longitude:
+          oneOf:
+          - type: number
+          - type: string
+        transport_type:
+          type: string
+        latitude:
+          oneOf:
+          - type: number
+          - type: string
+    stationCodes:
+      type: object
+      properties:
+        yandex_code:
+          type: string
+
+    ThreadResponse:
+      type: object
+      properties:
+        except_days:
+          type: string
+        arrival_date:
+          type: string
+        from:
+          type: object
+          properties:
+            code: { type: string }
+            title: { type: string }
+        to:
+          type: object
+          properties:
+            code: { type: string }
+            title: { type: string }
+        uid:
+          type: string
+        title:
+          type: string
+        number:
+          type: string
+        short_title:
+          type: string
+        days:
+          type: string
+        carrier:
+          $ref: '#/components/schemas/CarrierResponse'
+        vehicle:
+          type: string
+        transport_type:
+          type: string
+        transport_subtype:
+          type: object
+          properties:
+            title: { type: string }
+            code: { type: string }
+            color: { type: string }
+        stops:
+          type: array
+          items:
+            type: object
+            properties:
+              arrival:
+                type: string
+              departure:
+                type: string
+              duration:
+                type: number
+              stop_time:
+                type: number
+              station:
+                type: object
+                properties:
+                  code: { type: string }
+                  title: { type: string }
+                  station_type: { type: string }
+                  transport_type: { type: string }
+                  lat: { type: number }
+                  lng: { type: number }
+              terminal:
+                type: string
+              platform:
+                type: string
+        schedule:
+          type: array
+          items:
+            type: object
+            properties:
+              station:
+                type: object
+                properties:
+                  code: { type: string }
+                  title: { type: string }
+                  station_type: { type: string }
+                  transport_type: { type: string }
+                  lat: { type: number }
+                  lng: { type: number }
+              arrival: { type: string }
+              departure: { type: string }
+              duration: { type: integer }
+              stop_time: { type: integer }
+    Thread:
+      type: object
+      properties:
+        uid:
+          type: string
+        title:
+          type: string
+        number:
+          type: string
+        short_title:
+          type: string
+        transport_type:
+          type: string
+        carrier:
+          $ref: '#/components/schemas/carrier'
+        vehicle:
+          type: string
+        transport_subtype:
+          type: object
+          properties:
+            title: { type: string }
+            code: { type: string }
+            color: { type: string }
+

--- a/travel_schedule/AppDelegate.swift
+++ b/travel_schedule/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  travel_schedule
+//
+//  Created by David G on 05.04.2025.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/travel_schedule/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/travel_schedule/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travel_schedule/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/travel_schedule/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travel_schedule/Assets.xcassets/Contents.json
+++ b/travel_schedule/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travel_schedule/Base.lproj/LaunchScreen.storyboard
+++ b/travel_schedule/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/travel_schedule/Info.plist
+++ b/travel_schedule/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/travel_schedule/InternetError.swift
+++ b/travel_schedule/InternetError.swift
@@ -1,0 +1,12 @@
+//
+//  Error.swift
+//  travel_schedule
+//
+//  Created by Иван Иван on 17.04.2025.
+//
+
+import Foundation
+
+enum InternetError: Error {
+    case JsonFailed(String)
+}

--- a/travel_schedule/MainViewController.swift
+++ b/travel_schedule/MainViewController.swift
@@ -1,0 +1,159 @@
+//
+//  ViewController.swift
+//  travel_schedule
+//
+//  Created by David G on 05.04.2025.
+//
+
+import UIKit
+import OpenAPIURLSession
+
+class MainViewController: UIViewController {
+    
+    private lazy var client: Client? = {
+        do {
+            return try Client(
+                serverURL: Servers.Server1.url(),
+                transport: URLSessionTransport()
+            )
+        } catch {
+            print("Ошибка при создании клиента: \(error)")
+            return nil
+        }
+    }()
+    
+    private lazy var service: TrainSearchService? = {
+        guard let client else {
+            return nil
+        }
+        return TrainSearchService(
+            client: client,
+            apikey: "ApiKey"
+        )
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .red
+        //station()
+        //search()
+        //schedule()
+        //thread()
+        //settlement()
+        //carrier()
+        //stationList()
+        //copyright()
+    }
+    
+    func station() {
+        guard let service else { return }
+        Task {
+            do {
+                let result = try await service.getNearestStations(lat: 55.776501420708016,
+                                                                    lng: 37.657833455381116,
+                                                                    distance: 50)
+                print(result)
+            } catch {
+                print("Ошибка при получении станции: \(error)")
+            }
+        }
+    }
+    
+    func copiright() {
+        guard let service else { return }
+        Task {
+            do {
+                let result = try await service.getCopyright()
+                print(result)
+            } catch {
+                print("Ошибка при получении станции: \(error)")
+            }
+        }
+    }
+    
+    
+    func search() {
+        guard let service else { return }
+        Task {
+            do {
+                let result = try await service.getSearch(from: "s9637948", to: "s9761890", date: "2025-04-14")
+                print(result)
+            } catch {
+                print("Ошибка при получении станции: \(error)")
+            }
+        }
+    }
+    
+    func schedule() {
+        guard let service else { return }
+        Task {
+            do {
+                let result = try await service.getSchedule(station: "s2000002")
+                print(result)
+            } catch {
+                print("Ошибка при получении станции: \(error)")
+            }
+        }
+    }
+    
+    func thread() {
+        guard let service else { return }
+        Task {
+            do {
+                let result = try await service.getThread(uid: "empty_4_f9623369t9761925_114")
+                print(result)
+            } catch {
+                print("Ошибка при получении станции: \(error)")
+            }
+        }
+    }
+    
+    func settlement() {
+        guard let service else { return }
+        Task {
+            do {
+                let result = try await service.getNearestSettlement(lat: 59.864177, lng: 30.319163)
+                print(result)
+            } catch {
+                print("Ошибка при получении станции: \(error)")
+            }
+        }
+    }
+    
+    func carrier() {
+        guard let service else { return }
+        Task {
+            do {
+                let result = try await service.getCarrier(code: "112")
+                print(result)
+            } catch {
+                print("Ошибка при получении станции: \(error)")
+            }
+        }
+    }
+    
+    func stationList() {
+        guard let service else { return }
+        Task {
+            do {
+                let result = try await service.getCarrier(code: "112")
+                print(result)
+            } catch {
+                print("Ошибка при получении станции: \(error)")
+            }
+        }
+    }
+    
+    func copyright() {
+        guard let service else { return }
+        Task {
+            do {
+                let result = try await service.getCopyright()
+                print(result)
+            } catch {
+                print("Ошибка при получении станции: \(error)")
+            }
+        }
+    }
+}
+

--- a/travel_schedule/SceneDelegate.swift
+++ b/travel_schedule/SceneDelegate.swift
@@ -1,0 +1,57 @@
+//
+//  SceneDelegate.swift
+//  travel_schedule
+//
+//  Created by David G on 05.04.2025.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let scene = (scene as? UIWindowScene) else { return }
+        window = UIWindow(windowScene: scene)
+        window?.windowScene = scene
+        window?.makeKeyAndVisible()
+        window?.rootViewController = MainViewController()
+        
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/travel_schedule/TrainSearchService.swift
+++ b/travel_schedule/TrainSearchService.swift
@@ -1,0 +1,106 @@
+//
+//  NearestStationsService.swift
+//  travel_schedule
+//
+//  Created by David G on 10.04.2025.
+//
+
+import OpenAPIRuntime
+import OpenAPIURLSession
+import Foundation
+
+
+
+final class TrainSearchService: TrainSearchServiceProtocol {
+    
+    
+    private let client: Client
+    private let apikey: String
+    
+    init(client: Client, apikey: String) {
+        self.client = client
+        self.apikey = apikey
+    }
+    
+    func getSchedule(station: String) async throws -> Schedule {
+        let response = try await client.getSchedule(query: .init(apikey: apikey, station: station))
+        return try response.ok.body.json
+    }
+    
+    func getSearch(from: String, to: String, date: String) async throws -> Search {
+        let response = try await client.getSearch(query: .init(apikey: apikey, from: from, to: to))
+        return try response.ok.body.json
+    }
+    
+    func getNearestStations(lat: Double, lng: Double, distance: Int) async throws -> NearestStations {
+        let response = try await client.getNearestStations(query: .init(
+            apikey: apikey,
+            lat: lat,
+            lng: lng,
+            distance: distance
+        ))
+        return try response.ok.body.json
+    }
+    
+    func getThread(uid: String) async throws -> Thread {
+        let response = try await client.getThread(query: .init(
+            apikey: apikey,
+            uid: uid
+        ))
+        return try response.ok.body.json
+    }
+    
+    func getNearestSettlement(lat: Double, lng: Double) async throws -> NearestSettlement {
+        let response = try await client.getNearestSettlement(query: .init(
+            apikey: apikey,
+            lat: lat,
+            lng: lng
+        ))
+        return try response.ok.body.json
+    }
+    
+    func getCarrier(code: String) async throws -> Carrier {
+        let response = try await client.getCarrier(query: .init(
+            apikey: apikey,
+            code: code
+        ))
+        return try response.ok.body.json
+    }
+    
+    
+    func getCopyright() async throws -> Copyright {
+        let response = try await client.getCopyright(query: .init(apikey: apikey))
+        return try response.ok.body.json
+    }
+    
+    
+    
+    func getStationList() async throws -> StationList {
+        let response = try await client.getStationsList(query: .init(
+            apikey: apikey
+        ))
+        
+        let body = try response.ok.body.html
+        var buffer = Data()
+        for try await chunk in body {
+            buffer.append(contentsOf: chunk)
+        }
+        let decoder = JSONDecoder()
+        do {
+            return try decoder.decode(StationList.self, from: buffer)
+        } catch let DecodingError.dataCorrupted(context) {
+            print("Data corrupted:", context)
+        } catch let DecodingError.keyNotFound(key, context) {
+            print("Key '\(key)' not found:", context.debugDescription)
+        } catch let DecodingError.typeMismatch(type, context) {
+            print("Type '\(type)' mismatch:", context.debugDescription)
+        } catch let DecodingError.valueNotFound(value, context) {
+            print("Value '\(value)' not found:", context.debugDescription)
+        } catch {
+            print("Unknown decoding error:", error)
+            throw error
+        }
+        return StationList()
+    }
+}
+

--- a/travel_schedule/TrainSearchServiceProtocol.swift
+++ b/travel_schedule/TrainSearchServiceProtocol.swift
@@ -1,0 +1,28 @@
+//
+//  File.swift
+//  travel_schedule
+//
+//  Created by Иван Иван on 17.04.2025.
+//
+
+import Foundation
+
+typealias NearestStations = Components.Schemas.Stations
+typealias Search = Components.Schemas.searchResponse
+typealias Schedule = Components.Schemas.ScheduleResponse
+typealias Thread = Components.Schemas.ThreadResponse
+typealias NearestSettlement = Components.Schemas.NearestSettlementResponse
+typealias Carrier = Components.Schemas.CarrierResponse
+typealias StationList = Components.Schemas.StationsListResponse
+typealias Copyright = Components.Schemas.CopyrightResponse
+
+
+protocol TrainSearchServiceProtocol {
+    func getNearestStations(lat: Double, lng: Double, distance: Int) async throws -> NearestStations
+    func getSearch(from: String, to: String, date: String) async throws -> Search
+    func getSchedule(station: String) async throws -> Schedule
+    func getThread(uid: String)  async throws -> Thread
+    func getNearestSettlement(lat: Double, lng: Double) async throws -> NearestSettlement
+    func getCarrier(code: String) async throws -> Carrier
+    func getStationList() async throws -> StationList
+}


### PR DESCRIPTION
Описаны в yaml методы:
1)Расписание рейсов между станциями
2)Расписание рейсов по станции
3)Список станций следования
4)Список ближайших станций
5)Ближайший город
6)Информация о перевозчике
7)Список всех доступных станций
8)Копирайт Яндекс Расписаний
И добавлены их вызовы с переводом в текстовый формат